### PR TITLE
Set default "after" field to a past date

### DIFF
--- a/src/job_class.coffee
+++ b/src/job_class.coffee
@@ -542,7 +542,7 @@ class Job
     return @after new Date(new Date().valueOf() + wait)
 
   # Sets a time after which this job can run once it is saved
-  after: (time = new Date()) ->
+  after: (time = new Date(0)) ->
     if typeof time is 'object' and time instanceof Date
       after = time
     else


### PR DESCRIPTION
If we set it to new Date() and for some reason client's unixtime is
ahead of server's unixtime, job will wait in queue for no reason.
