### PR TITLE
Added exception handling to worker call

### DIFF
--- a/src/job_class.coffee
+++ b/src/job_class.coffee
@@ -180,7 +180,10 @@ class JobQueue
           _setImmediate @_process.bind(@)
           _setImmediate @_getWork.bind(@)
       cb = @_only_once next
-      @worker job, cb
+      try
+         @worker job, cb
+      catch err
+         cb()
 
   _stopGetWork: (callback) ->
     _clearInterval @_interval

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1498,6 +1498,14 @@ describe 'JobQueue', () ->
          20
       )
 
+   it 'should fail the job when an exception is thrown within the worker', (done) ->
+      q = Job.processJobs 'root', 'work', { pollInterval: 100 }, (job, cb) ->
+         throw new Error
+      q.shutdown { quiet: true }, () ->
+         assert.equal doneCalls, 0
+         assert.equal failCalls, 1
+         done()
+
    it 'should successfully accept multiple jobs from getWork', (done) ->
       count = 5
       q = Job.processJobs('root', 'workMax', { pollInterval: 100, prefetch: 4 }, (job, cb) ->


### PR DESCRIPTION
I ran into problems with errors being thrown within worker functions when used with meteor job collection. It seems the problem needed to be fixed here. There's also a corresponding pull request for meteor-job-collection adding the appropriate unit test.